### PR TITLE
Replace 11ty.io links with 11ty.dev links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # A simple starter kit for Eleventy
 
-Hylia is a lightweight [Eleventy](https://11ty.io) starter kit with [Netlify CMS](https://www.netlifycms.org/) pre-configured, so that you can one-click install a progressive, accessible blog in minutes. It also gives you a well organised starting point to extend it for yourself.
+Hylia is a lightweight [Eleventy](https://11ty.dev) starter kit with [Netlify CMS](https://www.netlifycms.org/) pre-configured, so that you can one-click install a progressive, accessible blog in minutes. It also gives you a well organised starting point to extend it for yourself.
 
 Get started now by **[deploying Hylia to Netlify.][deploy-to-netlify]**
 

--- a/src/index.md
+++ b/src/index.md
@@ -5,6 +5,6 @@ postsHeading: Latest posts
 archiveButtonText: See all posts
 socialImage: ''
 ---
-Hylia is a lightweight [Eleventy](https://11ty.io) starter kit with [Netlify CMS](https://www.netlifycms.org/) pre-configured, so that you can one-click install a progressive, accessible blog in minutes. It also gives you a well organised starting point to extend yourself.
+Hylia is a lightweight [Eleventy](https://11ty.dev) starter kit with [Netlify CMS](https://www.netlifycms.org/) pre-configured, so that you can one-click install a progressive, accessible blog in minutes. It also gives you a well organised starting point to extend yourself.
 
 Get started now by [deploying Hylia to Netlify.](https://app.netlify.com/start/deploy?repository=https://github.com/andybelldesign/hylia)


### PR DESCRIPTION
Per domain move announced at https://www.11ty.dev/news/moving-house/

`11ty.io` links redirect to `11ty.dev` just fine, so this wasn't necessary, but it was quick and easy to fix.